### PR TITLE
chore: using the right sentinl URL (OPS-4019)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ RUN yum install -y iproute net-tools
 
 USER kibana
 
-RUN /opt/kibana/bin/kibana-plugin install https://github.com/sirensolutions/sentinl/releases/download/tag-6.5.0-0/sentinl-v6.5.4.zip
+RUN /opt/kibana/bin/kibana-plugin install https://github.com/sirensolutions/sentinl/releases/download/tag-6.4.2-0/sentinl-v6.4.0.zip
 RUN chmod +x /usr/share/kibana/plugins/sentinl/phantomjs/phantomjs-2.1.1-linux-x86_64/bin/phantomjs


### PR DESCRIPTION
Sorry, I pushed the wrong sentinl URL. The build failed on master.

Tried that locally and it builds now.